### PR TITLE
Add AVX512 support

### DIFF
--- a/fastlwc-mmap-mt.c
+++ b/fastlwc-mmap-mt.c
@@ -47,7 +47,7 @@ struct lwcount count_mt(unsigned char *restrict addr, size_t size)
 				int words = SIMD_MASK_POPCNT(wbits)
 				            - SIMD_MASK_POPCNT(wbits & (wbits << 1))
 				            - (wcontinue && (wbits & 1));
-				wcontinue = wbits & (1u << (sizeof(SIMD_VEC) - 1));
+				wcontinue = wbits & (1ul << (sizeof(SIMD_VEC) - 1));
 				wcount += words;
 			}
 		}
@@ -69,7 +69,7 @@ struct lwcount count_mt(unsigned char *restrict addr, size_t size)
 		int words = SIMD_MASK_POPCNT(wbits)
 		            - SIMD_MASK_POPCNT(wbits & (wbits << 1))
 		            - (wcontinue && (wbits & 1));
-		wcontinue = wbits & (1u << (sizeof(SIMD_VEC) - 1));
+		wcontinue = wbits & (1ul << (sizeof(SIMD_VEC) - 1));
 		wcount += words;
 
 		remaining_size -= sizeof(SIMD_VEC);

--- a/fastlwc-mmap.c
+++ b/fastlwc-mmap.c
@@ -35,7 +35,7 @@ struct lwcount count(unsigned char *restrict addr, size_t remaining_size)
 		int words = SIMD_MASK_POPCNT(wbits)
 		            - SIMD_MASK_POPCNT(wbits & (wbits << 1))
 		            - (wcontinue && (wbits & 1));
-		wcontinue = wbits & (1u << (sizeof(SIMD_VEC) - 1));
+		wcontinue = wbits & (1ul << (sizeof(SIMD_VEC) - 1));
 		wcount += words;
 
 		remaining_size -= sizeof(SIMD_VEC);

--- a/fastlwc.c
+++ b/fastlwc.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
 			int words = SIMD_MASK_POPCNT(wbits)
 			            - SIMD_MASK_POPCNT(wbits & (wbits << 1))
 			            - (wcontinue && (wbits & 1));
-			wcontinue = wbits & (1u << (sizeof(SIMD_VEC) - 1));
+			wcontinue = wbits & (1ul << (sizeof(SIMD_VEC) - 1));
 			wcount += words;
 
 			rem -= sizeof(SIMD_VEC);

--- a/simd.h
+++ b/simd.h
@@ -4,7 +4,19 @@
 #include <inttypes.h>
 #include <nmmintrin.h>
 
-#ifdef __AVX2__
+
+#if defined(__AVX512F__) && defined(__AVX512BW__)
+#  include <immintrin.h>
+#  define SIMD_VEC           __m512i
+#  define SIMD_MASK          uint64_t
+#  define SIMD_SET8          _mm512_set1_epi8
+#  define SIMD_CMPGT8(X, Y)  _mm512_mask_blend_epi8(_mm512_cmpgt_epi8_mask(X, Y),SIMD_SET8(0),SIMD_SET8(-1))
+#  define SIMD_CMPEQ8(X, Y)  _mm512_mask_blend_epi8(_mm512_cmpeq_epi8_mask(X, Y),SIMD_SET8(0),SIMD_SET8(-1))
+#  define SIMD_AND           _mm512_and_si512
+#  define SIMD_OR            _mm512_or_si512
+#  define SIMD_CMASK8(X)     _cvtmask64_u64(_mm512_test_epi8_mask(X,SIMD_SET8(-1)))
+#  define SIMD_MASK_POPCNT   _mm_popcnt_u64
+#elif defined(__AVX2__)
 #  include <immintrin.h>
 #  define SIMD_VEC           __m256i
 #  define SIMD_MASK          uint32_t

--- a/simd.h
+++ b/simd.h
@@ -10,11 +10,11 @@
 #  define SIMD_VEC           __m512i
 #  define SIMD_MASK          uint64_t
 #  define SIMD_SET8          _mm512_set1_epi8
-#  define SIMD_CMPGT8(X, Y)  _mm512_mask_blend_epi8(_mm512_cmpgt_epi8_mask(X, Y),SIMD_SET8(0),SIMD_SET8(-1))
-#  define SIMD_CMPEQ8(X, Y)  _mm512_mask_blend_epi8(_mm512_cmpeq_epi8_mask(X, Y),SIMD_SET8(0),SIMD_SET8(-1))
+#  define SIMD_CMPGT8(X, Y)  _mm512_movm_epi8(_mm512_cmpgt_epi8_mask(X, Y))
+#  define SIMD_CMPEQ8(X, Y)  _mm512_movm_epi8(_mm512_cmpeq_epi8_mask(X, Y))
 #  define SIMD_AND           _mm512_and_si512
 #  define SIMD_OR            _mm512_or_si512
-#  define SIMD_CMASK8(X)     _cvtmask64_u64(_mm512_test_epi8_mask(X,SIMD_SET8(-1)))
+#  define SIMD_CMASK8(X)     _cvtmask64_u64(_mm512_movepi8_mask(X))
 #  define SIMD_MASK_POPCNT   _mm_popcnt_u64
 #elif defined(__AVX2__)
 #  include <immintrin.h>


### PR DESCRIPTION
This PR adds AVX512 support using the preprocessor-device that you have in place at the moment within `simd.h`. This will use `AVX512` and `AVX512BW`.

AVX512 doesn't use full-width mask registers(128-bit or 256-bit comparison-result registers) like SSE/AVX2 and instead uses the more compact k-mask registers(`_mmask16`, `_mmask32`, `_mmask64`). So I just had it convert the `k-mask` registers back into the flat binary registers using `_mm512_mask_blend_epi8` like so:

```cpp
_mm512_mask_blend_epi8(
    <the __mmask64 mask>,
    _mm512_set1_epi8(0),
    _mm512_set1_epi8(-1)
)
```

This way it is much more drop-in into your current `SIMD_CMPEQ8` and `SIMD_CMPGT8` pattern.

Some benchmarks for reference:
```
% inxi -C
CPU:
  Topology: 10-Core model: Intel Core i9-7900X bits: 64 type: MT MCP 

% ll -h ../words.txt
-rw-r--r-- 1 wunkolo wunkolo 2.5G Oct 27 17:00 ../words.txt

% /usr/bin/time -f "%E" cat ../words.txt >/dev/null
0:00.39

% /usr/bin/time -f "%E" ./bsd-wc ../words.txt
 256331381 256331382 2671776797 ../words.txt
0:05.47
```
with AVX2:
```
% /usr/bin/time -f "%E" ./fastlwc ../words.txt
 256331381 256331382 2671776797 ../words.txt
0:00.63

/usr/bin/time -f "%E" ./fastlwc-mmap ../words.txt                                                                           :(
 256331381 256331382 2671776797 ../words.txt
0:00.53

% /usr/bin/time -f "%E" ./fastlwc-mmap-mt ../words.txt
 256331381 256331382 2671776797 ../words.txt
0:00.12
```

with AVX512:
```
% /usr/bin/time -f "%E" ./fastlwc ../words.txt
 256331381 256331382 2671776797 ../words.txt
0:00.52

% /usr/bin/time -f "%E" ./fastlwc-mmap ../words.txt
 256331381 256331382 2671776797 ../words.txt
0:00.47

% /usr/bin/time -f "%E" ./fastlwc-mmap-mt ../words.txt
 256331381 256331382 2671776797 ../words.txt
0:00.11
```

With room for improvements if it only used the `k-mask` registers.