### PR TITLE
Add AVX512

### DIFF
--- a/simd.h
+++ b/simd.h
@@ -4,8 +4,19 @@
 #include <inttypes.h>
 #include <nmmintrin.h>
 
-
-#if defined(__AVX2__)
+#if defined(__AVX512F__) && defined(__AVX512BW__)
+#  include <immintrin.h>
+#  define SIMD_VEC           __m512i
+#  define SIMD_MASK          uint64_t
+#  define SIMD_SET8          _mm512_set1_epi8
+#  define SIMD_CMPGT8(X, Y)  _mm512_movm_epi8(_mm512_cmpgt_epi8_mask(X, Y))
+#  define SIMD_ADD8          _mm512_add_epi8
+#  define SIMD_CMPEQ8(X, Y)  _mm512_movm_epi8(_mm512_cmpeq_epi8_mask(X, Y))
+#  define SIMD_AND           _mm512_and_si512
+#  define SIMD_OR            _mm512_or_si512
+#  define SIMD_CMASK8(X)     _cvtmask64_u64(_mm512_movepi8_mask(X))
+#  define SIMD_MASK_POPCNT   _mm_popcnt_u64
+#elif defined(__AVX2__)
 #  include <immintrin.h>
 #  define SIMD_VEC           __m256i
 #  define SIMD_MASK          uint32_t


### PR DESCRIPTION
For real this time:

If you do not have AVX512 hardware, you can use [Intel's software development](https://software.intel.com/en-us/articles/intel-software-development-emulator) emulator to verify and test against foreign architectures.
```
% wc README.md
  59  327 2420 README.md
% ./bsd-wc README.md
      59     327    2420 README.md
% sde -- ./fastlwc README.md
      59     327    2420 README.md
% sde -- ./fastlwc-mmap README.md
      59     327    2420 README.md
% sde -- ./fastlwc-mmap-mt README.md
      59     327    2420 README.md
```
The juicy bit:
```
% gdb -batch -ex 'file fastlwc-mmap-mt' -ex 'disassemble count_mt' | grep -ozP '0x.*zmm.*\n'
0x00000000000016a0 <+224>:      vmovdqa64 zmm6,ZMMWORD PTR [rip+0xa16]        # 0x20c0
0x00000000000016aa <+234>:      vmovdqa64 zmm5,ZMMWORD PTR [rip+0xa4c]        # 0x2100
0x00000000000016b4 <+244>:      vmovdqa64 zmm4,ZMMWORD PTR [rip+0xa82]        # 0x2140
0x00000000000016be <+254>:      vmovdqa64 zmm3,ZMMWORD PTR [rip+0xab8]        # 0x2180
0x00000000000016d0 <+272>:      vmovdqa64 zmm2,ZMMWORD PTR [rdi]
0x00000000000016da <+282>:      vpaddb zmm1,zmm6,zmm2
0x00000000000016e0 <+288>:      vpcmpgtb k0,zmm1,zmm5
0x00000000000016e6 <+294>:      vmovdqa64 zmm1,zmm2
0x00000000000016f0 <+304>:      vpmovm2b zmm0,k0
0x00000000000016f6 <+310>:      vpcmpeqb k0,zmm2,zmm4
0x00000000000016fc <+316>:      vpmovm2b zmm2,k0
0x0000000000001702 <+322>:      vpcmpeqb k0,zmm1,zmm3
0x0000000000001708 <+328>:      vpmovm2b zmm1,k0
0x000000000000170e <+334>:      vpmovb2m k1,zmm2
0x0000000000001714 <+340>:      vpord  zmm0,zmm0,zmm1
0x000000000000171a <+346>:      vpmovb2m k2,zmm0

```